### PR TITLE
Drop PHP 7.4 support; update Alley domain; mark version 2.0.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 8.1, 8.0, 7.4 ]
+        php: [ 8.2, 8.1, 8.0 ]
         can_fail: [ false ]
     name: PHP ${{ matrix.php }}
     steps:

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the traverse/reshape package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 ## Unreleased
 
-Nothing yet.
+### Removed
+
+- PHP 7.4 support.
 
 ## 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 ## Unreleased
 
+Nothing yet.
+
+## 2.0.0
+
 ### Removed
 
 - PHP 7.4 support.

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "authors": [
     {
       "name": "Alley",
-      "email": "info@alley.co"
+      "email": "info@alley.com"
     }
   ],
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "lock": false
   },
   "require": {
-    "php": "^7.4 || ^8.0"
+    "php": "^8.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.8",

--- a/src/Alley/Internals/Traverser.php
+++ b/src/Alley/Internals/Traverser.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the traverse/reshape package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Alley/reshape.php
+++ b/src/Alley/reshape.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the traverse/reshape package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Alley/traverse.php
+++ b/src/Alley/traverse.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the traverse/reshape package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Alley/Fixtures/ArrayAccessible.php
+++ b/tests/Alley/Fixtures/ArrayAccessible.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the traverse/reshape package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Alley/ReshapeTest.php
+++ b/tests/Alley/ReshapeTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the traverse/reshape package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Alley/TraverseTest.php
+++ b/tests/Alley/TraverseTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the traverse/reshape package.
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.


### PR DESCRIPTION
## Summary

As titled.

## Notes for reviewers

None.

## Changelog entries

### Added

### Changed

### Deprecated

### Removed

- PHP 7.4 support.

### Fixed

### Security
